### PR TITLE
Add response navigation

### DIFF
--- a/Client/Components/Breadcrumbs.razor
+++ b/Client/Components/Breadcrumbs.razor
@@ -1,0 +1,57 @@
+@implements IDisposable
+@inject NavigationManager NavigationManager
+@using Microsoft.AspNetCore.Components.Routing
+
+<RadzenBreadCrumb class="mb-0">
+    @foreach (var item in Items)
+    {
+        <RadzenBreadCrumbItem Text="@item.Text" Path="@item.Url" />
+    }
+</RadzenBreadCrumb>
+
+@code {
+    private List<BreadcrumbItem> Items = new();
+
+    protected override void OnInitialized()
+    {
+        NavigationManager.LocationChanged += OnLocationChanged;
+        BuildItems();
+    }
+
+    private void OnLocationChanged(object sender, LocationChangedEventArgs e)
+    {
+        BuildItems();
+        InvokeAsync(StateHasChanged);
+    }
+
+    private void BuildItems()
+    {
+        Items.Clear();
+        var relative = NavigationManager.ToBaseRelativePath(NavigationManager.Uri);
+        var segments = string.IsNullOrEmpty(relative) ? Array.Empty<string>() : relative.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        string path = string.Empty;
+        Items.Add(new BreadcrumbItem("Home", ""));
+        foreach (var segment in segments)
+        {
+            path = string.IsNullOrEmpty(path) ? segment : $"{path}/{segment}";
+            Items.Add(new BreadcrumbItem(ToTitle(segment), path));
+        }
+    }
+
+    private static string ToTitle(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return string.Empty;
+        }
+        value = value.Replace('-', ' ');
+        return System.Globalization.CultureInfo.CurrentCulture.TextInfo.ToTitleCase(value);
+    }
+
+    public void Dispose()
+    {
+        NavigationManager.LocationChanged -= OnLocationChanged;
+    }
+
+    private record BreadcrumbItem(string Text, string Url);
+}

--- a/Client/Layout/MainLayout.razor
+++ b/Client/Layout/MainLayout.razor
@@ -15,7 +15,8 @@
 
             <!-- Column for user-related actions -->
             <RadzenColumn Size="10">
-                <RadzenStack AlignItems="AlignItems.Center" Orientation="Orientation.Horizontal" JustifyContent="JustifyContent.End">
+                <RadzenStack AlignItems="AlignItems.Center" Orientation="Orientation.Horizontal" JustifyContent="JustifyContent.SpaceBetween">
+                    <Breadcrumbs />
                     @if (waitingforuserload)
                     {
                         @if (username is null)

--- a/Client/Pages/DynamicForms/ViewResponse.razor
+++ b/Client/Pages/DynamicForms/ViewResponse.razor
@@ -17,7 +17,10 @@
             <span class="text-muted">Submitted by @responderName</span>
         }
     </div>
-
+    <div>
+        <button class="btn btn-sm btn-outline-primary me-2" @onclick="GoPrev" disabled="@(!HasPrev)">Prev</button>
+        <button class="btn btn-sm btn-outline-primary" @onclick="GoNext" disabled="@(!HasNext)">Next</button>
+    </div>
 </div>
 @if (!string.IsNullOrEmpty(deletedMessage))
 {
@@ -80,6 +83,10 @@ else
     private string? responderName;
     private IJSObjectReference? exportModule;
     private string? deletedMessage;
+    private List<int> responseIds = new();
+    private int currentIndex;
+    private bool HasPrev => currentIndex > 0;
+    private bool HasNext => currentIndex < responseIds.Count - 1;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -111,6 +118,14 @@ else
             }
 
             form = await respForm.Content.ReadFromJsonAsync<Form>();
+
+            var idsResp = await Http.GetAsync($"api/forms/{FormId}/responseIds");
+            if (idsResp.IsSuccessStatusCode)
+            {
+                responseIds = await idsResp.Content.ReadFromJsonAsync<List<int>>() ?? new();
+                responseIds.Sort();
+                currentIndex = responseIds.IndexOf(ResponseId);
+            }
 
             var resp = await Http.GetAsync($"api/forms/{FormId}/responses/{ResponseId}");
             if (!resp.IsSuccessStatusCode)
@@ -255,6 +270,24 @@ else
         else
         {
             await JS.InvokeVoidAsync("printElement", "printArea");
+        }
+    }
+
+    private void GoPrev()
+    {
+        if (HasPrev)
+        {
+            var prevId = responseIds[currentIndex - 1];
+            Navigation.NavigateTo($"/forms/{FormId}/responses/{prevId}");
+        }
+    }
+
+    private void GoNext()
+    {
+        if (HasNext)
+        {
+            var nextId = responseIds[currentIndex + 1];
+            Navigation.NavigateTo($"/forms/{FormId}/responses/{nextId}");
         }
     }
 

--- a/Client/_Imports.razor
+++ b/Client/_Imports.razor
@@ -12,6 +12,7 @@
 @using DynamicFormsApp.Client
 @using DynamicFormsApp.Client.Pages
 @using DynamicFormsApp.Client.Layout
+@using DynamicFormsApp.Client.Components
 @using DynamicFormsApp.Client.Services
 @using DynamicFormsApp.Shared.Models
 @using DynamicFormsApp.Shared.Services

--- a/Server/Controllers/FormsController.cs
+++ b/Server/Controllers/FormsController.cs
@@ -97,6 +97,30 @@ namespace DynamicFormsApp.Server.Controllers
             return Ok(row);
         }
 
+        [HttpGet("{id}/responseIds")]
+        public async Task<ActionResult<List<int>>> GetResponseIds(int id)
+        {
+            if (!Request.Cookies.TryGetValue("userName", out var user) || string.IsNullOrEmpty(user))
+            {
+                return Unauthorized();
+            }
+
+            var form = await _svc.GetFormAsync(id);
+            if (!form.IsActive)
+            {
+                var owner = await _userSvc.GetUserData(form.CreatedBy);
+                return StatusCode(410, new
+                {
+                    Message = "This form has been deleted. Please contact the owner.",
+                    Owner = owner?.DisplayName ?? form.CreatedBy,
+                    Email = owner?.Email
+                });
+            }
+
+            var ids = await _svc.GetResponseIdsAsync(id, user);
+            return Ok(ids);
+        }
+
 
         // GET /api/forms/{id}
         [HttpGet("{id}")]

--- a/Server/Services/DynamicFormService.cs
+++ b/Server/Services/DynamicFormService.cs
@@ -502,6 +502,39 @@ namespace DynamicFormsApp.Server.Services
             return row;
         }
 
+        public async Task<List<int>> GetResponseIdsAsync(int formId, string user)
+        {
+            if (!await HasResponseAccessAsync(formId, user))
+            {
+                throw new UnauthorizedAccessException();
+            }
+
+            var form = await _db.Forms.FindAsync(formId)
+                       ?? throw new InvalidOperationException("Form not found");
+            if (!form.IsActive)
+            {
+                throw new InvalidOperationException("Form inactive");
+            }
+
+            var rawName = SanitizeKey(form.Name);
+            var tableName = $"Form_{formId}_{rawName}";
+
+            using var conn = _db.Database.GetDbConnection();
+            if (conn.State != System.Data.ConnectionState.Open)
+                await conn.OpenAsync();
+
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"SELECT ResponseId FROM [{tableName}] ORDER BY ResponseId;";
+
+            using var reader = await cmd.ExecuteReaderAsync();
+            var ids = new List<int>();
+            while (await reader.ReadAsync())
+            {
+                ids.Add(reader.GetInt32(0));
+            }
+            return ids;
+        }
+
         private string MapToSqlType(string fieldType) => fieldType switch
         {
             "number" => "FLOAT",


### PR DESCRIPTION
## Summary
- implement endpoint to retrieve response IDs for a form
- expose response ID list via `FormsController`
- add Prev/Next buttons in `ViewResponse` page to switch between responses

## Testing
- `dotnet build DynamicFormsApp.sln -c Release` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_68700949589c8329a182d14b3dcc118b